### PR TITLE
Only use localStorage if `persist` is truthy

### DIFF
--- a/lib/superstore-sync.js
+++ b/lib/superstore-sync.js
@@ -31,17 +31,20 @@ exports.get = function(key) {
 };
 
 exports.set = function(key, value) {
-  try {
-    localStorage[key] = JSON.stringify(value);
-  } catch(err) {
+  if (persist) {
+    try {
+      localStorage[key] = JSON.stringify(value);
+    } catch(err) {
 
-    // Known iOS Private Browsing Bug - fall back to non-persistent storage
-    if (err.code === 22) {
-      persist = false;
-    } else {
-      throw err;
+      // Known iOS Private Browsing Bug - fall back to non-persistent storage
+      if (err.code === 22) {
+        persist = false;
+      } else {
+        throw err;
+      }
     }
   }
+
   store[key] = value;
   keys[key] = true;
 };


### PR DESCRIPTION
Aids debugging when in iOS private browsing mode and catching exceptions, and fasterer.
