### PR TITLE
v2.0.0 Promisify all methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ var Superstore = require('superstore');
 var store = new Superstore('foo');
 
 store.get('bar').then(function(value){
-	\\Do something with value
+  \\Do something with value
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,19 +14,29 @@ npm install superstore
 
 ## api
 
-Superstore is an uninstantiable module.  Its methods are:
+Superstore is an uninstantiable module.  All Superstore methods return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) which will resolve with the stored value. Its methods are:
 
-### #get(key, callback)
+### #get(key)
 
-### #set(key, value, callback)
+### #set(key, value)
 
-### #unset(key, callback)
+### #unset(key)
 
-### #clear(callback)
+### #clear()
+
+## Example usage
+
+```
+var Superstore = require('superstore');
+var store = new Superstore('foo');
+
+store.get('bar').then(function(value){
+	\\Do something with value
+});
+```
 
 ## todo
 
 - JSDoc comments and automatically generating documentation.
 - Should clear and unset be merged?  
-- Split superstore-sync into its own git repository
 - Split the tests up into those that test the async layer and those that test the localStorage layer.  (The point above is a dependency)

--- a/lib/superstore.js
+++ b/lib/superstore.js
@@ -4,7 +4,7 @@
  * @author Matt Andrews <matthew.andrews@ft.com>
  * @copyright The Financial Times [All Rights Reserved]
  */
-
+require('es6-promise').polyfill();
 require('setimmediate');
 var sync = require('superstore-sync');
 
@@ -18,29 +18,34 @@ function Superstore(namespace) {
   }
 
   this.namespace = "_ss."+namespace+".";
+}
+
+Superstore.prototype.get = function(key) {
+  return new Promise(function(resolve) {
+	setImmediate(resolve, sync.get(this.namespace+key));
+  }.bind(this));
 };
 
-Superstore.prototype.get = function(key, cb) {
-  setImmediate(cb, undefined, sync.get(this.namespace+key));
+Superstore.prototype.set = function(key, value) {
+  return new Promise(function(resolve){
+	setImmediate(resolve, sync.set(this.namespace+key, value));
+  }.bind(this));
 };
 
-Superstore.prototype.set = function(key, value, cb) {
-  sync.set(this.namespace+key, value);
-  if (cb) setImmediate(cb);
-};
-
-Superstore.prototype.unset = function(key, cb) {
-  sync.unset(this.namespace+key);
-  if (cb) setImmediate(cb);
+Superstore.prototype.unset = function(key) {
+  return new Promise(function(resolve) {
+    setImmediate(resolve, sync.unset(this.namespace+key));
+  }.bind(this));
 };
 
 /**
  * #clear(true) and #clear() clear cache and persistent layer, #clear(false) only clears cache
  *
  */
-Superstore.prototype.clear = function(cb) {
-  sync.clear(this.namespace);
-  if (cb) setImmediate(cb);
+Superstore.prototype.clear = function() {
+  return new Promise(function(resolve) {
+    setImmediate(resolve, sync.clear(this.namespace));
+  }.bind(this));
 };
 
 module.exports = Superstore;

--- a/lib/superstore.js
+++ b/lib/superstore.js
@@ -22,13 +22,13 @@ function Superstore(namespace) {
 
 Superstore.prototype.get = function(key) {
   return new Promise(function(resolve) {
-	setImmediate(resolve, sync.get(this.namespace+key));
+    setImmediate(resolve, sync.get(this.namespace+key));
   }.bind(this));
 };
 
 Superstore.prototype.set = function(key, value) {
   return new Promise(function(resolve){
-	setImmediate(resolve, sync.set(this.namespace+key, value));
+    setImmediate(resolve, sync.set(this.namespace+key, value));
   }.bind(this));
 };
 

--- a/lib/superstore.js
+++ b/lib/superstore.js
@@ -4,7 +4,6 @@
  * @author Matt Andrews <matthew.andrews@ft.com>
  * @copyright The Financial Times [All Rights Reserved]
  */
-require('es6-promise').polyfill();
 require('setimmediate');
 var sync = require('superstore-sync');
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "buster": "~0.6.12",
     "grunt-istanbul": "~0.2.2",
     "phantomjs": "~1.9.1",
-    "q": "~0.9.6"
+    "q": "~0.9.6",
+    "es6-promise": "^2.3.0"
   },
   "repository": {
     "type": "git",
@@ -32,7 +33,6 @@
   "author": "Matt Andrews <matthew.andrews@ft.com>",
   "license": "MIT",
   "dependencies": {
-    "es6-promise": "^2.3.0",
     "setimmediate": "~1.0.1",
     "superstore-sync": "^1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "author": "Matt Andrews <matthew.andrews@ft.com>",
   "license": "MIT",
   "dependencies": {
+    "es6-promise": "^2.3.0",
     "setimmediate": "~1.0.1",
     "superstore-sync": "^1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superstore",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Local storage, without the bugs, and an asynchronous API",
   "main": "lib/superstore.js",
   "engines": {

--- a/test/buster.js
+++ b/test/buster.js
@@ -4,7 +4,8 @@ config['superstore'] = {
   rootPath: '../',
   environment: 'browser',
   sources: [
-    'coverage/build/superstore.js',
+    'node_modules/es6-promise/dist/es6-promise.js',
+	'coverage/build/superstore.js',
     'node_modules/q/q.js'
   ],
   tests: [

--- a/test/tests/superstore.test.js
+++ b/test/tests/superstore.test.js
@@ -12,11 +12,11 @@ var dupStore = new Superstore("testing123");
 
 function getLocalStorage(key) {
   return localStorage[store.namespace+key];
-};
+}
 
 function setLocalStorage(key, val) {
   return localStorage[store.namespace+key] = val;
-};
+}
 
 tests["setUp"] = function() {
   localStorage.clear();
@@ -37,11 +37,11 @@ tests[prefix + "Should be able to read things (twice) from local storage"] = fun
   var deferred = Q.defer();
   var deferred2 = Q.defer();
   store.set('keyTwo', 3884).then(function(){
-	return store.get('keyTwo');
+    return store.get('keyTwo');
   }).then(function(value) {
     assert.equals(3884, value);
     deferred.resolve();
-	return store.get('keyTwo');
+    return store.get('keyTwo');
   }).then(function(value) {
     assert.equals(3884, value);
     deferred2.resolve();
@@ -78,7 +78,7 @@ tests[prefix + "Should json encode and decode objects"] = function() {
   var key = 'keySeventh';
   store.set(key, obj).then(function(value) {
     assert.equals(obj, value);
-	assert.equals(JSON.stringify(obj), getLocalStorage(key));
+    assert.equals(JSON.stringify(obj), getLocalStorage(key));
     deferred.resolve();
   });
   return deferred.promise;
@@ -103,12 +103,12 @@ tests[prefix + "#clear() clears only our namespaced data"] = function() {
   store.set('keyTenth', 'A').then(function() {
     return store.set('keyEleventh', 'B');
   }).then(function() {
-      return store.clear();
+    return store.clear();
   }).then(function() {
-	assert.equals(undefined, getLocalStorage("keyTenth"));
-	assert.equals(undefined, getLocalStorage("keyEleventh"));
-	assert.equals("123",     localStorage["other"]);
-	deferred.resolve();
+    assert.equals(undefined, getLocalStorage("keyTenth"));
+    assert.equals(undefined, getLocalStorage("keyEleventh"));
+    assert.equals("123",     localStorage["other"]);
+    deferred.resolve();
   });
   return deferred.promise;
 };
@@ -123,8 +123,8 @@ tests["watch for changes in other processes"] = function() {
     window.dispatchEvent(event);
     return store.get('key13');
   }).then(function(value) {
-      assert.equals(value, 'B');
-      deferred.resolve();
+     assert.equals(value, 'B');
+     deferred.resolve();
   });
   return deferred.promise;
 };

--- a/test/tests/superstore.test.js
+++ b/test/tests/superstore.test.js
@@ -24,11 +24,11 @@ tests["setUp"] = function() {
 
 tests["Should be able to set and get data against a key"] = function() {
   var deferred = Q.defer();
-  store.set('quay', 'val you', function() {
-    store.get('quay', function(err, value) {
+  store.set('quay', 'val you').then(function() {
+    return store.get('quay');
+  }).then(function(value) {
       assert.equals('val you', value);
       deferred.resolve();
-    });
   });
   return deferred.promise;
 };
@@ -36,12 +36,13 @@ tests["Should be able to set and get data against a key"] = function() {
 tests[prefix + "Should be able to read things (twice) from local storage"] = function() {
   var deferred = Q.defer();
   var deferred2 = Q.defer();
-  setLocalStorage("keyTwo", 3884);
-  store.get('keyTwo', function(err, value) {
+  store.set('keyTwo', 3884).then(function(){
+	return store.get('keyTwo');
+  }).then(function(value) {
     assert.equals(3884, value);
     deferred.resolve();
-  });
-  store.get('keyTwo', function(err, value) {
+	return store.get('keyTwo');
+  }).then(function(value) {
     assert.equals(3884, value);
     deferred2.resolve();
   });
@@ -53,23 +54,8 @@ tests[prefix + "Should be able to read things (twice) from local storage"] = fun
 tests[prefix + "Should be able to unset things"] = function() {
   var deferred = Q.defer();
   getLocalStorage("keyThree", "Hello");
-  store.unset('keyThree', function() {
+  store.unset('keyThree').then(function() {
     assert.equals(undefined, getLocalStorage("keyThree"));
-    deferred.resolve();
-  });
-  return deferred.promise;
-};
-
-tests[prefix + "Shouldn't need to provide a set callback to set"] = function() {
-  store.set("keyFour", "OK");
-  assert.equals(getLocalStorage("keyFour"), "\"OK\"");
-};
-
-tests[prefix + "Shouldn't need to provide a set callback to unset"] = function() {
-  var deferred = Q.defer();
-  setLocalStorage("keyFifth", true);
-  store.unset('keyFifth', function() {
-    assert.equals(undefined, getLocalStorage("keyFifth"));
     deferred.resolve();
   });
   return deferred.promise;
@@ -77,7 +63,7 @@ tests[prefix + "Shouldn't need to provide a set callback to unset"] = function()
 
 tests["Getting an unset key should return a nully value"] = function() {
   var deferred = Q.defer();
-  store.get("keySixth", function(err, value) {
+  store.get("keySixth").then(function(value) {
     assert.equals(value, undefined);
     deferred.resolve();
   });
@@ -89,8 +75,10 @@ tests[prefix + "Should json encode and decode objects"] = function() {
   var obj = {
     test: [1,4,6,7]
   };
-  store.set('keySeventh', obj, function() {
-    assert.equals(JSON.stringify(obj), getLocalStorage("keySeventh"));
+  var key = 'keySeventh';
+  store.set(key, obj).then(function(value) {
+    assert.equals(obj, value);
+	assert.equals(JSON.stringify(obj), getLocalStorage(key));
     deferred.resolve();
   });
   return deferred.promise;
@@ -99,44 +87,44 @@ tests[prefix + "Should json encode and decode objects"] = function() {
 tests["Set should fire a callback"] = function() {
   var deferred = Q.defer();
   var spy = this.spy();
-  store.set('keyNinth', 'A', function () {
+  store.set('keyNinth', 'A').then(function () {
     spy();
     deferred.resolve();
   });
   return deferred.promise.then(function() {
     assert.called(spy);
-  });;
+  });
 };
 
 tests[prefix + "#clear() clears only our namespaced data"] = function() {
   var deferred = Q.defer();
   localStorage["other"] = "123";
 
-  store.set('keyTenth', 'A', function() {
-    store.set('keyEleventh', 'B', function() {
-      store.clear(function() {
-        assert.equals(undefined, getLocalStorage("keyTenth"));
-        assert.equals(undefined, getLocalStorage("keyEleventh"));
-        assert.equals("123",     localStorage["other"]);
-        deferred.resolve();
-      });
-    });
+  store.set('keyTenth', 'A').then(function() {
+    return store.set('keyEleventh', 'B');
+  }).then(function() {
+      return store.clear();
+  }).then(function() {
+	assert.equals(undefined, getLocalStorage("keyTenth"));
+	assert.equals(undefined, getLocalStorage("keyEleventh"));
+	assert.equals("123",     localStorage["other"]);
+	deferred.resolve();
   });
   return deferred.promise;
 };
 
 tests["watch for changes in other processes"] = function() {
   var deferred = Q.defer();
-  store.set('key13', 'A', function() {
+  store.set('key13', 'A').then(function() {
     var event = new CustomEvent("storage");
     event.key = store.namespace+"key13";
     event.newValue = "\"B\"";
 
     window.dispatchEvent(event);
-    store.get('key13', function(err, value) {
+    return store.get('key13');
+  }).then(function(value) {
       assert.equals(value, 'B');
       deferred.resolve();
-    });
   });
   return deferred.promise;
 };
@@ -155,11 +143,11 @@ tests["throw error if no namespace given"] = function() {
 tests["be able to set in one instance of superstore and get from another instance"] = function() {
   var deferred = Q.defer();
 
-  store.set('dupKey', 'hello', function() {
-    dupStore.get('dupKey', function(err, value) {
-      assert.equals("hello", value);
-      deferred.resolve();
-    });
+  store.set('dupKey', 'hello').then(function() {
+    return dupStore.get('dupKey');
+  }).then(function(value) {
+    assert.equals("hello", value);
+    deferred.resolve();
   });
   return deferred.promise;
 };


### PR DESCRIPTION
This introduces a breaking change which converts all methods from a callback pattern to return Promises instead.

- Add ES6 Promise polyfill as dep 
- Update methods to return promise
- Update tests
- Update readme
- Bump version

