### PR TITLE
Update api to be inline with superstore-sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+bower_components
 node_modules
 *.swp
 *.swo

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # superstore [![Build Status](https://travis-ci.org/matthew-andrews/superstore.png?branch=master)](https://travis-ci.org/matthew-andrews/superstore)
 
-Superstore is a simple lightweight asynchronous wrapper around localStorage.  Its features include:
+Superstore is a simple lightweight asynchronous wrapper around the Web Storage APIs [localStorage](https://developer.mozilla.org/en/docs/Web/API/Window/localStorage) and [sessionStorage](https://developer.mozilla.org/en/docs/Web/API/Window/sessionStorage).  Its features include:
+
+If you require an syncronous version please use [superstore](https://github.com/matthew-andrews/superstore) instead.
 
 - It is [resilient to iOS's strange behaviour in private browsing mode](http://stackoverflow.com/questions/14555347/html5-localstorage-doesnt-works-in-ios-safari-private-browsing).
 - By making use of [setImmediate](https://github.com/NobleJS/setImmediate) its callbacks are truly asynchronous whilst still being cross-browser and performant (compared with `setTimeout(function() {}, 0)` [which introduces a delay of *at least* 10ms](https://developer.mozilla.org/en-US/docs/Web/API/window.setTimeout#Minimum.2F_maximum_delay_and_timeout_nesting)).
@@ -8,8 +10,14 @@ Superstore is a simple lightweight asynchronous wrapper around localStorage.  It
 
 ## installation
 
+### npm
 ```
-npm install superstore
+npm install superstore --save
+```
+
+### bower
+```
+bower superstore --save
 ```
 
 ## api
@@ -28,7 +36,7 @@ Superstore is an uninstantiable module.  All Superstore methods return a [Promis
 
 ```
 var Superstore = require('superstore');
-var store = new Superstore('foo');
+var store = new Superstore('localStorage', 'foo');
 
 store.get('bar').then(function(value){
   \\Do something with value

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "superstore",
+  "version": "3.0.1",
+  "homepage": "https://github.com/matthew-andrews/superstore",
+  "authors": [
+    "Matt Andrews <matthew.andrews@ft.com>"
+  ],
+  "description": "Web Storage APIs, without the bugs, and an asynchronous API.",
+  "main": "lib/superstore.js",
+  "keywords": [
+    "localstorage",
+    "sessionstorage"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "superstore-sync": "~2.0.0"
+  }
+}

--- a/lib/superstore.js
+++ b/lib/superstore.js
@@ -4,36 +4,35 @@
  * @author Matt Andrews <matthew.andrews@ft.com>
  * @copyright The Financial Times [All Rights Reserved]
  */
-require('setimmediate');
 var sync = require('superstore-sync');
 
 var keys = {};
 var store = {};
 var persist = true;
 
-function Superstore(namespace) {
+function Superstore(type, namespace) {
   if(!namespace) {
     throw "Namespace required";
   }
-
+  this.store = sync[type];
   this.namespace = "_ss."+namespace+".";
 }
 
 Superstore.prototype.get = function(key) {
   return new Promise(function(resolve) {
-    setImmediate(resolve, sync.get(this.namespace+key));
+	resolve(this.store.get(this.namespace+key));
   }.bind(this));
 };
 
 Superstore.prototype.set = function(key, value) {
   return new Promise(function(resolve){
-    setImmediate(resolve, sync.set(this.namespace+key, value));
+    resolve(this.store.set(this.namespace+key, value));
   }.bind(this));
 };
 
 Superstore.prototype.unset = function(key) {
   return new Promise(function(resolve) {
-    setImmediate(resolve, sync.unset(this.namespace+key));
+    resolve(this.store.unset(this.namespace+key));
   }.bind(this));
 };
 
@@ -43,7 +42,7 @@ Superstore.prototype.unset = function(key) {
  */
 Superstore.prototype.clear = function() {
   return new Promise(function(resolve) {
-    setImmediate(resolve, sync.clear(this.namespace));
+    resolve(this.store.clear(this.namespace));
   }.bind(this));
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superstore",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Local storage, without the bugs, and an asynchronous API",
   "main": "lib/superstore.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "author": "Matt Andrews <matthew.andrews@ft.com>",
   "license": "MIT",
   "dependencies": {
-    "setimmediate": "~1.0.1",
-    "superstore-sync": "^1.1.0"
+    "superstore-sync": "^2.0.0"
   }
 }

--- a/test/tests/superstore.test.js
+++ b/test/tests/superstore.test.js
@@ -7,8 +7,8 @@ try {
 }
 
 var tests = {};
-var store    = new Superstore("testing123");
-var dupStore = new Superstore("testing123");
+var store    = new Superstore("local", "testing123");
+var dupStore = new Superstore("local", "testing123");
 
 function getLocalStorage(key) {
   return localStorage[store.namespace+key];


### PR DESCRIPTION
Brings in the new changes from `superstore-sync`allowing users to supply a storage type `local` or `session` and creates a `bower.json` mainfest so as to publish to bower.

/cc @matthew-andrews 